### PR TITLE
open file +typo fix manga-cli

### DIFF
--- a/manga-cli
+++ b/manga-cli
@@ -78,9 +78,9 @@ create_file() {
   else
 
     echo "Converting to cbz..."
-    zip -q "$image_dir$name-$chapterNumber.cbz" "$image_dir*.jpg"
-
-    rm "$image_dir/*.jpg"
+    zip -q $image_dir$name-$chapterNumber.cbz $image_dir*.jpg
+    
+    rm $image_dir/*.jpg
     clear
     zathura "$image_dir$name-$chapterNumber.cbz" &
     choose_next
@@ -179,7 +179,7 @@ while [ "$1" != "" ]; do
   --pdf)
 
     file_format="pdf"
-    download_manga
+    search_manga
     exit 1
     ;;
 


### PR DESCRIPTION
corrected the file opening section with the fix proposed @eduardomdc . And corrected the typo in the flags section from "download_manga" to "search_manga"