### PR TITLE
Fix errors

### DIFF
--- a/manga-cli
+++ b/manga-cli
@@ -70,8 +70,8 @@ select_chapter() {
 create_file() {
   if [ $file_format == "pdf" ]; then
     echo "Converting to pdf..."
-    convert $($ls -v $image_dir*.jpg) "$image_dir$name-$chapterNumber.pdf"
-    rm "$image_dir/*.jpg"
+    convert $(ls -v $image_dir*.jpg) "$image_dir$name-$chapterNumber.pdf"
+    rm "$image_dir/"*.jpg
     clear
     zathura "$image_dir$name-$chapterNumber.pdf" &
     choose_next
@@ -80,7 +80,7 @@ create_file() {
     echo "Converting to cbz..."
     zip -q $image_dir$name-$chapterNumber.cbz $image_dir*.jpg
 
-    rm "$image_dir/*.jpg"
+    rm "$image_dir/"*.jpg
     clear
     zathura "$image_dir$name-$chapterNumber.cbz" &
     choose_next


### PR DESCRIPTION
I am not sure how it can work on linux, but it doesn't work on macOS.

In the line 73 there is an extra $ sign, I suppose it is a typo...

Also the quotes when placed after * in `rm` create an issue since quoting the * stops it from globbing https://unix.stackexchange.com/questions/326584/rm-command-in-bash-script-does-not-work-with-variable

So it leads to the following error:
```zsh
rm: /Users/alexfreik/.cache/manga-cli/*.jpg: No such file or directory
```