### PR TITLE
Fix color overflow

### DIFF
--- a/manga-cli
+++ b/manga-cli
@@ -10,6 +10,7 @@ pdf_viewer=zathura
 Green='\033[0;32m'
 Yellow='\033[0;33m'
 White='\033[0;37m'
+EndColor='\033[0m'
 
 mangaName="${@: -1}"
 prog="$0"
@@ -34,6 +35,10 @@ help_text() {
 		        -o  select pdf viewer 
 		        -h  displays this message
 	EOF
+}
+
+end_color() {
+  echo -n -e "${EndColor}"
 }
 
 search_manga() {
@@ -211,3 +216,4 @@ main() {
 }
 
 main
+end_color

--- a/manga-cli
+++ b/manga-cli
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+
+trap exit_script SIGINT SIGTERM
+
 search_url="https://m.manganelo.com/search/story/"
 image_dir="$HOME/.cache/manga-cli/"
 
@@ -36,6 +39,15 @@ help_text() {
 		        -h  displays this message
 	EOF
 }
+
+
+exit_script() {
+  trap - SIGINT SIGTERM
+  echo "Exiting script"
+  end_color
+  exit 1
+}
+
 
 end_color() {
   echo -n -e "${EndColor}"
@@ -171,6 +183,7 @@ choose_next() {
     download_chapter
 
   elif [ "${option}" = "q" ]; then
+    end_color
     exit 1
 
   else


### PR DESCRIPTION
I've noticed that terminating the script in many ways (like `ctrl+c` or even the `q` option) makes the custom text colors stay, so I added some things that will make the text color return to normal after quitting the script

(ngl I don't think "color overflow" is the right term, but I read it as that in another repo so yeah)